### PR TITLE
[add] `emPreverb` and `emCompound`

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Modules are defined in `config.py`. The current toolchain consists of the follow
 - `emPhon-noIPA-comments` (`emphon-noipa-comments`, `emPhon-noipa-comments`): The emPhon phonetic transcriber without IPAization but with comment lines
 - `emPhon-noIPA-nocomments` (`emphon-noipa-nocomments`, `emPhon-noipa-nocomments`): The emPhon phonetic transcriber without IPAization and comment lines
 - `emPreverb` (`preverb`): module to connect a preverb to the verb or verb-derivative token to which it belong.
+- `emCompound` (`compound`): module to annotate compound boundaries.
 
 For an overview see [the topology of the current toolchain](docs/emtsv_modules.pdf)
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Modules are defined in `config.py`. The current toolchain consists of the follow
 - `emPhon-IPA-nocomments` (`emphon-ipa-nocomments`, `emPhon-ipa-nocomments`): The emPhon phonetic transcriber with IPAization but without comment lines
 - `emPhon-noIPA-comments` (`emphon-noipa-comments`, `emPhon-noipa-comments`): The emPhon phonetic transcriber without IPAization but with comment lines
 - `emPhon-noIPA-nocomments` (`emphon-noipa-nocomments`, `emPhon-noipa-nocomments`): The emPhon phonetic transcriber without IPAization and comment lines
+- `emPreverb` (`preverb`): module to connect a preverb to the verb or verb-derivative token to which it belong.
 
 For an overview see [the topology of the current toolchain](docs/emtsv_modules.pdf)
 

--- a/config.py
+++ b/config.py
@@ -190,6 +190,11 @@ emphon_noipa_nocomments = ('emphon', 'EmPhon', 'emPhon phonetic transcriber with
                            {'source_fields': {'form', 'anas'}, 'target_fields': ['phon'], 'include_sentence': False,
                             'transcriber_opts': {'ipaize': False, 'optional_palatal_assimilation': False}})
 
+# emPreverb ############################################################################################################
+
+em_preverb = ( 'emPreverb', 'EmPreverb', 'connect preverbs', (),
+        { 'source_fields': {'form', 'anas', 'lemma', 'xpostag'}, 'target_fields': ['separated', 'previd']})
+
 ########################################################################################################################
 
 # Map module personalities to aliases...
@@ -232,7 +237,8 @@ tools = [(em_token, ('tok', 'emToken')),
          (emphon_ipa_comments, ('emphon-ipa-comments', 'emPhon-ipa-comments', 'emPhon-IPA-comments')),
          (emphon_ipa_nocomments, ('emphon-ipa-nocomments', 'emPhon-ipa-nocomments', 'emPhon-IPA-nocomments')),
          (emphon_noipa_comments, ('emphon-noipa-comments', 'emPhon-noipa-comments', 'emPhon-noIPA-comments')),
-         (emphon_noipa_nocomments, ('emphon-noipa-nocomments', 'emPhon-noipa-nocomments', 'emPhon-noIPA-nocomments'))
+         (emphon_noipa_nocomments, ('emphon-noipa-nocomments', 'emPhon-noipa-nocomments', 'emPhon-noIPA-nocomments')),
+         (em_preverb, ('preverb', 'emPreverb')),
          ]
 
 # cat input.txt | ./main.py tok,morph,pos,conv-morph,dep -> cat input.txt | ./main.py tok-dep

--- a/config.py
+++ b/config.py
@@ -193,7 +193,7 @@ emphon_noipa_nocomments = ('emphon', 'EmPhon', 'emPhon phonetic transcriber with
 # emPreverb ############################################################################################################
 
 em_preverb = ( 'emPreverb', 'EmPreverb', 'connect preverbs', (),
-        { 'source_fields': {'form', 'anas', 'lemma', 'xpostag'}, 'target_fields': ['separated', 'previd']})
+        { 'source_fields': {'form', 'anas', 'lemma', 'xpostag'}, 'target_fields': ['prev', 'previd', 'prevpos']})
 
 # emCompound ###########################################################################################################
 

--- a/config.py
+++ b/config.py
@@ -195,6 +195,11 @@ emphon_noipa_nocomments = ('emphon', 'EmPhon', 'emPhon phonetic transcriber with
 em_preverb = ( 'emPreverb', 'EmPreverb', 'connect preverbs', (),
         { 'source_fields': {'form', 'anas', 'lemma', 'xpostag'}, 'target_fields': ['separated', 'previd']})
 
+# emCompound ###########################################################################################################
+
+em_compound = ( 'emCompound', 'EmCompound', 'annotate compound boundaries', (),
+        { 'source_fields': {'anas', 'lemma', 'xpostag'}, 'target_fields': ['compound']})
+
 ########################################################################################################################
 
 # Map module personalities to aliases...
@@ -239,6 +244,7 @@ tools = [(em_token, ('tok', 'emToken')),
          (emphon_noipa_comments, ('emphon-noipa-comments', 'emPhon-noipa-comments', 'emPhon-noIPA-comments')),
          (emphon_noipa_nocomments, ('emphon-noipa-nocomments', 'emPhon-noipa-nocomments', 'emPhon-noIPA-nocomments')),
          (em_preverb, ('preverb', 'emPreverb')),
+         (em_compound, ('compound', 'emCompound')),
          ]
 
 # cat input.txt | ./main.py tok,morph,pos,conv-morph,dep -> cat input.txt | ./main.py tok-dep

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ https://github.com/vadno/emconll/releases/download/v1.0.0/emconll-1.0.0-py3-none
 https://github.com/vadno/emzero/releases/download/v1.0.0/emzero-1.0.0-py3-none-any.whl
 https://github.com/ELTE-DH/emstanza/releases/download/v1.0.3/emstanza-1.0.3-py3-none-any.whl
 emphon>=1.3.1,<2.0.0
+https://github.com/ril-lexknowrep/empreverb/releases/download/v1.0.0/empreverb-1.0.0-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,5 +29,5 @@ https://github.com/vadno/emconll/releases/download/v1.0.0/emconll-1.0.0-py3-none
 https://github.com/vadno/emzero/releases/download/v1.0.0/emzero-1.0.0-py3-none-any.whl
 https://github.com/ELTE-DH/emstanza/releases/download/v1.0.3/emstanza-1.0.3-py3-none-any.whl
 emphon>=1.3.1,<2.0.0
-https://github.com/ril-lexknowrep/empreverb/releases/download/v1.0.0/empreverb-1.0.0-py3-none-any.whl
+https://github.com/ril-lexknowrep/empreverb/releases/download/v2.0.0/empreverb-2.0.0-py3-none-any.whl
 https://github.com/ril-lexknowrep/emcompound/releases/download/v1.0.2/emcompound-1.0.2-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ https://github.com/vadno/emzero/releases/download/v1.0.0/emzero-1.0.0-py3-none-a
 https://github.com/ELTE-DH/emstanza/releases/download/v1.0.3/emstanza-1.0.3-py3-none-any.whl
 emphon>=1.3.1,<2.0.0
 https://github.com/ril-lexknowrep/empreverb/releases/download/v1.0.0/empreverb-1.0.0-py3-none-any.whl
+https://github.com/ril-lexknowrep/emcompound/releases/download/v1.0.2/emcompound-1.0.2-py3-none-any.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ https://github.com/vadno/emzero/releases/download/v1.0.0/emzero-1.0.0-py3-none-a
 https://github.com/ELTE-DH/emstanza/releases/download/v1.0.3/emstanza-1.0.3-py3-none-any.whl
 emphon>=1.3.1,<2.0.0
 https://github.com/ril-lexknowrep/empreverb/releases/download/v2.0.0/empreverb-2.0.0-py3-none-any.whl
-https://github.com/ril-lexknowrep/emcompound/releases/download/v1.0.2/emcompound-1.0.2-py3-none-any.whl
+https://github.com/ril-lexknowrep/emcompound/releases/download/v1.0.3/emcompound-1.0.3-py3-none-any.whl


### PR DESCRIPTION
I would like to add two new :tada: modules to `emtsv`.
1. `emPreverb` connects a preverb to the verb or verb-derivative token to which it belong.
2. `emCompound` annotates compound boundaries.

Review and merge, please.